### PR TITLE
Add disk-cached CGC coefficients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,11 @@ authors = ["Maarten Van Damme <Maarten.VanDamme@UGent.be> and Jutho Haegeman <ju
 version = "0.1.6"
 
 [deps]
-JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SparseArrayKit = "a9a3c162-d163-4c15-8926-b8794fbefed2"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
@@ -20,6 +20,9 @@ SparseArrayKit = "0.3"
 TensorKit = "0.11, 0.12"
 TensorOperations = "4"
 julia = "1.6"
+LinearAlgebra = "1.6"
+Serialization = "1.6"
+Scratch = "1"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -4,19 +4,21 @@ authors = ["Maarten Van Damme <Maarten.VanDamme@UGent.be> and Jutho Haegeman <ju
 version = "0.1.6"
 
 [deps]
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SparseArrayKit = "a9a3c162-d163-4c15-8926-b8794fbefed2"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 
 [compat]
+LRUCache = "1"
 RationalRoots = "0.1 - 0.2"
 SparseArrayKit = "0.3"
 TensorKit = "0.11, 0.12"
 TensorOperations = "4"
-LRUCache = "1"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,48 @@ Status](https://github.com/maartenvd/SUNRepresentations.jl/workflows/CI/badge.sv
 
 Compute Clebsch-Gordan coefficients for general SU(N) groups. Reimplementation of [arXiv:1009.0437](https://arxiv.org/pdf/1009.0437.pdf). Compatibility / interoperability with [TensorKit.jl](https://github.com/Jutho/TensorKit.jl).
 
+## Installation
+
+```julia
+julia> using Pkg; Pkg.add("SUNRepresentations")
+```
+
+## Usage
+
+```julia
+using TensorKit, SUNRepresentations
+I = SUNIrrep(2, 1, 0)
+println("$I ⊗ $I = $(collect(I ⊗ I))")
+```
+
+```
+Irrep[SU{3}]((2, 1, 0)) ⊗ Irrep[SU{3}]((2, 1, 0)) = SUNIrrep{3}[(0, 0, 0), (4, 2, 0), (3, 3, 0), (2, 1, 0), (3, 0, 0)]
+```
+
+## Caching Clebsch-Gordan coefficients
+
+Because the computation of Clebsch-Gordan coefficients can be quite expensive, it is
+recommended to cache them. By default, the coefficients are only cached in memory, and will
+be lost when the Julia session is closed. In order to cache the coefficients that are
+currently stored in memory to disk, you can call `SUNRepresentations.sync_disk_cache(N)`.
+This will create a scratchfile, which will then automatically be used the next time you want
+to compute Clebsch-Gordan coefficients. Often, it can be useful to precompute a large set of
+Clebsch-Gordan coefficients (in parallel) and store them on disk. This can be done using the
+`SUNRepresentations.precompute_disk_cache(N, a_max)` function. This has the additional
+benefit that the coefficients can be computed in parallel.
+
+```julia-repl
+julia> SUNRepresentations.precompute_disk_cache(3, 2) # precompute all coefficients for SU(3) with a_max = 2
+[ Info: Computed CGC: (0, 0, 0) ⊗ (0, 0, 0) → (0, 0, 0) (0.016749002 sec)
+[ Info: Computed CGC: (1, 1, 0) ⊗ (1, 0, 0) → (0, 0, 0) (0.111028889 sec)
+    ⋮
+[ Info: Computed CGC: (1, 1, 0) ⊗ (1, 1, 0) → (2, 2, 0) (0.38386373 sec)
+[ Info: Computed CGC: (1, 0, 0) ⊗ (1, 1, 0) → (0, 0, 0) (9.1176e-5 sec)
+
+julia> SUNRepresentations.cache_info()
+[ Info: CGC cache for SU(3) with eltype Float64 contains 0 / 100000 CGCs (1.4225616455078125 Mib)
+[ Info: CGC cache file 3-Float64.bin contains 165 CGCs (0.3374509811401367 Mib)
+```
+
 TODO:
 * Documentation
-* Thread-safety of cache structures
-* Ability to store/load generated cache data

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -7,6 +7,8 @@ using LinearAlgebra
 using TensorKit
 using TensorKit: fusiontensor, Nsymbol
 using LRUCache
+using Scratch
+using JLD2
 
 export SUNIrrep, basis, weight, Zweight, creation, annihilation, highest_weight, dim
 export directproduct, CGC

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -5,7 +5,7 @@ using SparseArrayKit
 using RationalRoots
 using LinearAlgebra
 using TensorKit
-using TensorKit: fusiontensor, Nsymbol
+using TensorKit: SU, fusiontensor, Nsymbol
 using LRUCache
 using Scratch
 using Serialization

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -8,7 +8,7 @@ using TensorKit
 using TensorKit: fusiontensor, Nsymbol
 using LRUCache
 using Scratch
-using JLD2
+using Serialization
 
 export SUNIrrep, basis, weight, Zweight, creation, annihilation, highest_weight, dim
 export directproduct, CGC
@@ -65,6 +65,7 @@ function directproduct(s1::SUNIrrep{N}, s2::SUNIrrep{N}) where {N}
     return result
 end
 
+include("caching.jl")
 include("clebschgordan.jl")
 include("sector.jl")
 

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -1,0 +1,158 @@
+struct CGCCache{T,N}
+    data::LRU{NTuple{3,SUNIrrep{N}},SparseArray{T,4}} # cached CGC tensors
+    offsets::Dict{NTuple{3,SUNIrrep{N}},Tuple{UInt,UInt}} # existing hash to file positions
+
+    function CGCCache{T,N}(; maxsize=10^5) where {T,N}
+        data = LRU{NTuple{3,SUNIrrep{N}},SparseArray{T,4}}(; maxsize)
+        offsets = if isfile(offsets_path(N, T))
+            deserialize(offsets_path(N, T))
+        else
+            Dict{NTuple{3,SUNIrrep{N}},Tuple{UInt,UInt}}()
+        end
+        return new{T,N}(data, offsets)
+    end
+end
+
+# List of CGC caches for each N and T
+const CGC_CACHES = LRU{Any,CGCCache}(; maxsize=10)
+
+const CGC_CACHE_PATH = @get_scratch!("CGC")
+offsets_path(N, T) = joinpath(CGC_CACHE_PATH, "$N-$T-offsets.bin")
+cache_path(N, T) = joinpath(CGC_CACHE_PATH, "$N-$T.bin")
+
+function Base.get!(f::Function, cache::CGCCache{T, N}, key::NTuple{3,SUNIrrep{N}}) where {T, N}
+    return get!(cache.data, key) do
+        # if the key is not in the cache, check if it is in the file
+        if haskey(cache.offsets, key)
+            start, stop = cache.offsets[key]
+            fn = cache_path(N, T)
+            return open(fn, "r") do io
+                return load_disk_cache_entry(io, start, stop)
+            end
+        else
+            return f()
+        end
+    end
+end
+
+function load_disk_cache_entry(io::IO, start::UInt, stop::UInt)
+    seek(io, start)
+    buf = read(io, stop - start)
+    return deserialize(IOBuffer(buf))
+end
+
+function store_disk_cache_entry(io::IO, start::UInt, val)
+    seek(io, start)
+    buf = IOBuffer()
+    serialize(buf, val)
+    posbuf = UInt(position(buf))
+    write(io, buf.data[1:posbuf])
+    return UInt(position(io))
+end
+
+"""
+    sync_disk_cache(N, [T=Float64])
+
+Sync the CGC cache for ``SU(N)`` with eltype `T` to disk.
+
+!!! warning
+    This function is not thread-safe. In particular, it is not safe to call this function while other threads are accessing the cache.
+"""
+sync_disk_cache(N, T=Float64) = sync_disk_cache(CGC_CACHES[(N, T)])
+function sync_disk_cache(cache::CGCCache{T, N}) where {T,N}
+    # store data
+    open(cache_path(N, T), "a+") do fid
+        seekend(fid)
+        for key in setdiff(keys(cache.data), keys(cache.offsets))
+            start = UInt(position(fid))
+            stop = store_disk_cache_entry(fid, start, cache.data[key])
+            cache.offsets[key] = (start, stop)
+        end
+    end
+    
+    # store offsets
+    open(offsets_path(N, T), "w") do fid
+        serialize(fid, cache.offsets)
+    end
+end
+
+"""
+    clear_disk_cache(N, T)
+
+Clear the CGC cache for ``SU(N)`` with eltype `T` from disk.
+"""
+clear_disk_cache!(N, T=Float64) = clear_disk_cache(CGC_CACHES[(N, T)])
+function clear_disk_cache!(cache::CGCCache{T, N}) where {T,N}
+    isfile(cache_path(N, T)) && rm(cache_path(N, T))
+    isfile(offsets_path(N, T)) && rm(offsets_path(N, T))
+    cache.offsets = Dict{NTuple{3,SUNIrrep{N}},Tuple{UInt,UInt}}()
+    return nothing
+end
+
+"""
+    clear_ram_cache!(N, T; sync=true)
+
+Clear the CGC cache for ``SU(N)`` with eltype `T` from RAM. If `sync` is `true`, the cache will first be synced to disk.
+"""
+clear_ram_cache!(N, T=Float64; sync::Bool=true) = clear_ram_cache!(CGC_CACHES[(N, T)]; sync)
+function clear_ram_cache!(cache::CGCCache; sync::Bool=true)
+    sync && sync_disk_cache(cache)
+    empty!(cache.data)
+    return nothing
+end
+
+"""
+    cache_info()
+
+Print information about the CGC caches.
+"""
+function cache_info()
+    # print RAM caches
+    if isempty(CGC_CACHES)
+        @info "CGC cache is empty"
+    else
+        for ((N, T), val) in CGC_CACHES
+            sz = Base.summarysize(val) / 1024^2
+            @info "CGC cache for SU($N) with eltype $T contains $(val.data.currentsize) / $(val.data.maxsize) CGCs ($sz Mib)"
+        end
+    end
+    
+    # print disk caches
+    if !isdir(CGC_CACHE_PATH)
+        @info "CGC cache directory $(CGC_CACHE_PATH) is empty"
+    else
+        for fn in readdir(CGC_CACHE_PATH)
+            if endswith(fn, ".bin") && !endswith(fn, "offsets.bin")
+                sz = filesize(joinpath(CGC_CACHE_PATH, fn)) / 1024^2
+                num = length(deserialize(joinpath(CGC_CACHE_PATH, fn[1:end-4] * "-offsets.bin")))
+                @info "CGC cache file $fn contains $num CGCs ($sz Mib)"
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+    cache_populate(a_max, N, [T=Float64])
+
+Populate the CGC cache for ``SU(N)`` with eltype `T` with all CGCs with Dynkin labels up to
+``a_max``. It is recommended to sync the cache to disk after calling this function.
+
+See also: [`sync_disk_cache`](@ref)
+"""
+function cache_populate(a_max::Int, N, T::Type{<:Number}=Float64)
+    all_dynkinlabels = CartesianIndices(ntuple(Returns(a_max + 1), N - 1))
+    @sync begin
+        for I₁ in all_dynkinlabels
+            s1 = SUNIrrep(reverse(cumsum(I₁.I .- 1))..., 0)
+            for I₂ in all_dynkinlabels
+                s2 = SUNIrrep(reverse(cumsum(I₂.I .- 1))..., 0)
+                for s3 in s1 ⊗ s2
+                    maximum(dynkin_labels(s3)) <= a_max &&
+                        Threads.@spawn CGC(T, s1, s2, s3)
+                end
+            end
+        end
+    end
+    return nothing
+end

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -81,11 +81,11 @@ end
 
 Clear the CGC cache for ``SU(N)`` with eltype `T` from disk.
 """
-clear_disk_cache!(N, T=Float64) = clear_disk_cache(CGC_CACHES[(N, T)])
+clear_disk_cache!(N, T=Float64) = clear_disk_cache!(CGC_CACHES[(N, T)])
 function clear_disk_cache!(cache::CGCCache{T, N}) where {T,N}
     isfile(cache_path(N, T)) && rm(cache_path(N, T))
     isfile(offsets_path(N, T)) && rm(offsets_path(N, T))
-    cache.offsets = Dict{NTuple{3,SUNIrrep{N}},Tuple{UInt,UInt}}()
+    empty!(cache.offsets)
     return nothing
 end
 
@@ -133,14 +133,14 @@ function cache_info()
 end
 
 """
-    cache_populate(a_max, N, [T=Float64])
+    precompute_disk_cache(N, a_max, [T=Float64])
 
 Populate the CGC cache for ``SU(N)`` with eltype `T` with all CGCs with Dynkin labels up to
-``a_max``. It is recommended to sync the cache to disk after calling this function.
+``a_max``.
 
 See also: [`sync_disk_cache`](@ref)
 """
-function cache_populate(a_max::Int, N, T::Type{<:Number}=Float64)
+function precompute_disk_cache(N, a_max::Int=3, T::Type{<:Number}=Float64)
     all_dynkinlabels = CartesianIndices(ntuple(Returns(a_max + 1), N - 1))
     @sync begin
         for I₁ in all_dynkinlabels
@@ -154,5 +154,6 @@ function cache_populate(a_max::Int, N, T::Type{<:Number}=Float64)
             end
         end
     end
+    clear_ram_cache!(N, T; sync=true)
     return nothing
 end

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -27,7 +27,7 @@ function Base.get!(f::Function, cache::CGCCache{T, N}, key::NTuple{3,SUNIrrep{N}
             start, stop = cache.offsets[key]
             fn = cache_path(N, T)
             return open(fn, "r") do io
-                return load_disk_cache_entry(io, start, stop)
+                return load_disk_cache_entry(io, start, stop)::SparseArray{T,4}
             end
         else
             return f()

--- a/src/clebschgordan.jl
+++ b/src/clebschgordan.jl
@@ -17,7 +17,7 @@ end
 
 CGC(s1::I, s2::I, s3::I) where {I<:SUNIrrep} = CGC(Float64, s1, s2, s3)
 function CGC(::Type{T}, s1::SUNIrrep{N}, s2::SUNIrrep{N}, s3::SUNIrrep{N}) where {T,N}
-    cache = get!(CGC_CACHES, (N,T), CGCCache{T,N}())
+    cache = get!(CGC_CACHES, (N,T), CGCCache{T,N}())::CGCCache{T,N}
     return get!(cache, (s1, s2, s3)) do
         return _CGC(T, s1, s2, s3)
     end

--- a/src/clebschgordan.jl
+++ b/src/clebschgordan.jl
@@ -20,12 +20,15 @@ function CGC(T::Type{<:Real}, s1::SUNIrrep{N}, s2::SUNIrrep{N}, s3::SUNIrrep{N})
     cachetype = LRU{Tuple{SUNIrrep{N},SUNIrrep{N},SUNIrrep{N}},SparseArray{T,4}}
     cache = get!(CGCCACHE, (N, T), cachetype(; maxsize=10^5))::cachetype
     return get!(cache, (s1, s2, s3)) do
-        return _CGC(Float64, s1, s2, s3)
+        return _CGC(T, s1, s2, s3)
     end
 end
 function _CGC(T::Type{<:Real}, s1::I, s2::I, s3::I) where {I<:SUNIrrep}
-    CGC = highest_weight_CGC(T, s1, s2, s3)
-    lower_weight_CGC!(CGC, s1, s2, s3)
+    Δt = @elapsed begin
+        CGC = highest_weight_CGC(T, s1, s2, s3)
+        lower_weight_CGC!(CGC, s1, s2, s3)
+    end
+    @info "Computed CGC: $s1 ⊗ $s2 → $s3 ($Δt sec)"
     return CGC
 end
 

--- a/src/sector.jl
+++ b/src/sector.jl
@@ -95,3 +95,5 @@ function _Rsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N}) where {N}
     @tensor R[-1; -2] := conj(B[1, 2, -2]) * A[2, 1, -1]
     return Array(R)
 end
+
+dynkin_labels(I::SUNIrrep{N}) where {N} = ntuple(i -> I.I[i] - I.I[i + 1], N - 1)

--- a/src/sector.jl
+++ b/src/sector.jl
@@ -25,7 +25,7 @@ Base.one(::Type{SUNIrrep{N}}) where {N} = SUNIrrep(ntuple(n -> 0, N))
 
 TensorKit.FusionStyle(::Type{SUNIrrep{N}}) where {N} = TensorKit.GenericFusion()
 Base.isreal(::Type{<:SUNIrrep}) = true
-TensorKit.BraidingStyle(::Type{<:SUNIrrep}) = TensorKit.Bosonic();
+TensorKit.BraidingStyle(::Type{<:SUNIrrep}) = TensorKit.Bosonic()
 
 function TensorKit.:⊗(s1::SUNIrrep{N}, s2::SUNIrrep{N}) where {N}
     return TensorKit.SectorSet{SUNIrrep{N}}(keys(directproduct(s1, s2)))


### PR DESCRIPTION
This is my attempt at providing a thread-safe and performant way of having cached coefficients saved on disk.
Importantly, I avoid the use of JLD2, which should be slightly faster but less portable.
Additionally, this provides the ability to precompute a large number of CGCs in parallel, which can be useful on clusters.

Thoughts and comments welcome.