### PR TITLE
Support for multiple name types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,21 +6,30 @@ version = "0.1.6"
 [deps]
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
 SparseArrayKit = "a9a3c162-d163-4c15-8926-b8794fbefed2"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 
+[weakdeps]
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+
+[extensions]
+SUNRepresentationsLatexifyExt = "Latexify"
+
 [compat]
+Latexify = "0.16"
+LRUCache = "1"
 RationalRoots = "0.1 - 0.2"
 SparseArrayKit = "0.3"
 TensorKit = "0.11, 0.12"
 TensorOperations = "4"
-LRUCache = "1"
 julia = "1.6"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -28,4 +37,4 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [targets]
-test = ["Test", "Random", "Combinatorics", "TestExtras", "TensorKit", "TupleTools"]
+test = ["Test", "Random", "Combinatorics", "TestExtras", "TensorKit", "TupleTools", "Latexify"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,44 @@ Status](https://github.com/maartenvd/SUNRepresentations.jl/workflows/CI/badge.sv
 
 Compute Clebsch-Gordan coefficients for general SU(N) groups. Reimplementation of [arXiv:1009.0437](https://arxiv.org/pdf/1009.0437.pdf). Compatibility / interoperability with [TensorKit.jl](https://github.com/Jutho/TensorKit.jl).
 
-TODO:
+## Conventions
+
+By default, irreps are denoted by their `N` weights, which are equivalent to the number of
+boxes in each row of the Young tableau, and this is also how they are stored. For example,
+the fundamental representation of SU(3) is denoted by `SUNIrrep(1, 0, 0)`, and the adjoint
+representation by `SUNIrrep(2, 1, 0)`. Nevertheless, we also support using `N - 1` Dynkin
+labels, which are denoted using `Vector{Int}`. For example, the fundamental representation
+of SU(3) is denoted by `SUNIrrep([1, 0])`, and the adjoint representation by
+`SUNIrrep([1, 1])`. Finally, it is also possible to use the dimensional name which is often
+used in physics, e.g. `SUNIrrep{3}("3")` and `SUNIrrep{3}("8")`.
+
+The display of irreps can be changed in a persistent way by setting the `display_mode`
+preference:
+
+```julia-repl
+julia> using SUNRepresentations
+julia> for mode in ["weight", "dynkin", "dimension"]
+           SUNRepresentations.display_mode(mode)
+           @show SUNIrrep(2,2,2,0)
+       end
+SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]((2, 2, 2, 0))
+SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]([0, 0, 2])
+SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]("10")
+```
+
+## Extensions
+
+This package supports outputting the irreps to a LaTeX format via a package extension for
+`Latexify.jl`. To use this extension, load `Latexify.jl` and `SUNRepresentations.jl` and
+then the following should work:
+
+```julia-repl
+julia> using SUNRepresentations, Latexify
+julia> latexify(SUNIrrep{4}("10⁺"))
+L"$\overline{\textbf{10}}$"
+```
+
+## TODO
+
 * Documentation
-* Thread-safety of cache structures
 * Ability to store/load generated cache data

--- a/ext/SUNRepresentationsLatexifyExt.jl
+++ b/ext/SUNRepresentationsLatexifyExt.jl
@@ -1,0 +1,25 @@
+module SUNRepresentationsLatexifyExt
+
+using SUNRepresentations
+using SUNRepresentations: dimname, parse_dimname
+using Latexify
+using Latexify: @latexrecipe, LaTeXString
+
+@latexrecipe function f(x::SUNIrrep)
+    ## set parameters
+    env --> :inline
+    
+    ## convert into latex string
+    d, numprimes, conjugate = parse_dimname(dimname(x))
+    str_new = conjugate ? "\\overline{\\textbf{$d}}" : "\\textbf{$d}"
+    if numprimes == 1
+        str_new *= "^\\prime"
+    elseif numprimes > 1
+        str_new *= "^{" * repeat("\\prime", numprimes) * "}"
+    end
+    return LaTeXString(str_new)
+end
+
+Base.show(io::IO, ::MIME"text/latex", x::SUNIrrep) = print(io, latexify(x))
+
+end

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -10,6 +10,8 @@ using LRUCache
 
 export SUNIrrep, basis, weight, Zweight, creation, annihilation, highest_weight, dim
 export directproduct, CGC
+export dynkin_label, congruency, index
+export cartanmatrix, inverse_cartanmatrix, dimname
 
 struct SUNIrrep{N} <: TensorKit.AbstractIrrep{TensorKit.SU{N}}
     I::NTuple{N,Int}
@@ -21,6 +23,9 @@ _normalize(s::SUNIrrep) = (I = weight(s); return SUNIrrep(I .- I[end]))
 
 Base.getproperty(s::SUNIrrep{N}, f::Symbol) where {N} = f == :N ? N : getfield(s, f)
 weight(s::SUNIrrep) = getfield(s, :I)
+
+Base.string(s::SUNIrrep) = dimname(s)
+Base.show(io::IO, ::MIME"text/plain", s::SUNIrrep) = print(io, "SUNIrrep{$(s.N)}($s)")
 
 function TensorKit.dim(s::SUNIrrep)
     N = s.N
@@ -65,5 +70,6 @@ end
 
 include("clebschgordan.jl")
 include("sector.jl")
+include("naming.jl")
 
 end

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -12,7 +12,7 @@ using Preferences
 export SUNIrrep, basis, weight, Zweight, creation, annihilation, highest_weight, dim
 export directproduct, CGC
 export SU, SU₃, SU₄, SU₅, SU3Irrep, SU4Irrep, SU5Irrep
-export dynkin_label, congruency, index
+export dynkin_label, congruency
 
 """
     struct SUNIrrep{N} <: TensorKit.AbstractIrrep{SU{N}}

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -5,27 +5,79 @@ using SparseArrayKit
 using RationalRoots
 using LinearAlgebra
 using TensorKit
-using TensorKit: fusiontensor, Nsymbol
+using TensorKit: fusiontensor, Nsymbol, SU
 using LRUCache
+using Preferences
 
 export SUNIrrep, basis, weight, Zweight, creation, annihilation, highest_weight, dim
 export directproduct, CGC
+export SU, SU₃, SU₄, SU₅, SU3Irrep, SU4Irrep, SU5Irrep
 export dynkin_label, congruency, index
-export cartanmatrix, inverse_cartanmatrix, dimname
 
-struct SUNIrrep{N} <: TensorKit.AbstractIrrep{TensorKit.SU{N}}
+"""
+    struct SUNIrrep{N} <: TensorKit.AbstractIrrep{SU{N}}
+
+The irrep of SU(N) with highest weight `I`.
+
+# Constructors
+
+    SUNIrrep(I::NTuple{N,Int})
+    SUNIrrep(args::Vararg{Int})
+
+Constructs the `SU{N}` irrep with highest weight `I` or `args...`.
+
+    SUNIrrep{N}(name::AbstractString)
+
+Constructs the `SU{N}` irrep with dimensional name `name`. Note that the parameter `N` is
+required to uniquely identify the irrep.
+
+    SUNIrrep(a::Vector{Int})
+
+Constructs the `SU{N}` irrep with highest weight `a = [a₁, a₂, …, aₙ₋₁]`.
+"""
+struct SUNIrrep{N} <: TensorKit.AbstractIrrep{SU{N}}
     I::NTuple{N,Int}
 end
-SUNIrrep(args::Vararg{Int}) = SUNIrrep(args)
+
+SUNIrrep(args::Vararg{Int,N}) where {N} = SUNIrrep{N}(args)
+SUNIrrep{N}(args::Vararg{Int}) where {N} = SUNIrrep{N}(args)
+
+SUNIrrep(a::Vector{Int}) = SUNIrrep{length(a)+1}(a)
+function SUNIrrep{N}(a::Vector{Int}) where {N}
+    @assert length(a) == N - 1
+    return SUNIrrep{N}(reverse(cumsum(reverse(a)))..., 0)
+end
+
+function SUNIrrep{N}(name::AbstractString) where {N}
+    if N == 3
+        name == generate_dimname(6, 0, false) && return SUNIrrep{N}(2, 0, 0)
+        name == generate_dimname(6, 0, true) && return SUNIrrep{N}(2, 2, 0)
+    end
+    
+    d, numprimes, conjugate = parse_dimname(name)
+    max_dynkin = max_dynkin_label(SUNIrrep{N})
+
+    same_dim_irreps = irreps_by_dim(SUNIrrep{N}, d, max_dynkin)
+    same_dim_ids = unique!(index.(same_dim_irreps))
+    length(same_dim_ids) < numprimes + 1 &&
+        throw(ArgumentError("Either the name $name is not valid for SU{$N} or the irrep has at least one Dynkin label higher than $max_dynkin.\nYou can expand the search space with `SUNRepresentations.max_dynkin_label(SUNIrrep{$N}) = a`."))
+    
+    id = same_dim_ids[numprimes + 1]
+    same_id_irreps = filter(x -> index(x) == id, same_dim_irreps)
+    @assert length(same_id_irreps) <= 2
+    return conjugate ? last(same_id_irreps) : first(same_id_irreps)
+end
+
+const SU3Irrep = SUNIrrep{3}
+const SU4Irrep = SUNIrrep{4}
+const SU5Irrep = SUNIrrep{5}
+
 Base.isless(s1::SUNIrrep{N}, s2::SUNIrrep{N}) where {N} = isless(s1.I, s2.I)
 
 _normalize(s::SUNIrrep) = (I = weight(s); return SUNIrrep(I .- I[end]))
 
 Base.getproperty(s::SUNIrrep{N}, f::Symbol) where {N} = f == :N ? N : getfield(s, f)
 weight(s::SUNIrrep) = getfield(s, :I)
-
-Base.string(s::SUNIrrep) = dimname(s)
-Base.show(io::IO, ::MIME"text/plain", s::SUNIrrep) = print(io, "SUNIrrep{$(s.N)}($s)")
 
 function TensorKit.dim(s::SUNIrrep)
     N = s.N

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -8,21 +8,19 @@ function display_mode(mode::AbstractString)
     return oldmode
 end
 
-function Base.print(io::IO, s::SUNIrrep)
-    display_mode() == "weight" ? print(io, weightname(s)) :
-        display_mode() == "dynkin" ? print(io, dynkinname(s)) :
-        display_mode() == "dimension" ? print(io, dimname(s)) :
-        error("Invalid display mode $(display_mode()).")
-end
 function Base.show(io::IO, s::SUNIrrep)
+    name = display_mode() == "weight" ? weightname(s) :
+           display_mode() == "dynkin" ? dynkinname(s) :
+           display_mode() == "dimension" ? dimname(s) :
+           error("Invalid display mode $(display_mode()).")
     if get(io, :typeinfo, nothing) === typeof(s)
-        print(io, s)
+        print(io, name)
     else
         if display_mode() == "dimension"
             # special case to add "" around the dimension
-            print(io, TensorKit.type_repr(typeof(s)), "(\"", dimname(s), "\")")
+            print(io, TensorKit.type_repr(typeof(s)), "(\"", name, "\")")
         else
-            print(io, TensorKit.type_repr(typeof(s)), "(", s, ")")
+            print(io, TensorKit.type_repr(typeof(s)), "(", name, ")")
         end
     end
     return nothing

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -1,0 +1,138 @@
+"""
+    dynkin_label(I::SUNIrrep)
+
+Gives the labels of the Dynkin diagram of the SU(N) irrep `I` as a tuple of `N - 1`
+integers. These are related to the Young Tableau by `aᵢ = λᵢ - λᵢ₊₁` where `λᵢ` is the
+number of boxes in the `i`th row of the Young Tableau.
+"""
+dynkin_label(I::SUNIrrep{N}) where {N} = Z2weight(highest_weight(I))
+
+function from_dynkin_label(a::NTuple{N,Int}) where {N}
+    w = reverse(cumsum(reverse(a)))
+    return SUNIrrep(w..., 0)
+end
+
+max_dynkin_label(::Type{<:SUNIrrep}) = 3
+
+"""
+    congruency(I::SUNIrrep)
+
+Returns the congruency class of the SU(N) irrep `I`, which expresses to what class of the ℤₙ-grading the irrep belongs.
+"""
+function congruency(I::SUNIrrep{N}) where {N}
+    return sum(((k, aₖ),) -> aₖ * k, enumerate(dynkin_label(I))) % N
+end
+
+cartanmatrix(I::SUNIrrep) = cartanmatrix(typeof(I))
+function cartanmatrix(::Type{SUNIrrep{N}}) where {N}
+    A = zeros(Int, N - 1, N - 1)
+    for i in 1:(N - 1), j in 1:(N - 1)
+        A[i, j] = 2 * (i == j) - (i == j + 1) - (i == j - 1)
+    end
+    return A
+end
+inverse_cartanmatrix(I::SUNIrrep) = inverse_cartanmatrix(typeof(I))
+function inverse_cartanmatrix(::Type{SUNIrrep{N}}) where {N}
+    A⁻¹ = zeros(Int, N - 1, N - 1)
+    for i in 1:(N - 1), j in i:(N - 1)
+        A⁻¹[i, j] = i * (N - j)
+        A⁻¹[j, i] = A⁻¹[i, j]
+    end
+    return A⁻¹ .// N
+end
+
+"""
+    index(I::SUNIrrep)
+
+Returns the index of the SU(N) irrep `I`
+"""
+function index(s::SUNIrrep)
+    N = s.N
+    w = dynkin_label(s)
+    metric = inverse_cartanmatrix(typeof(s))
+    id = dim(s) * dot(collect(w), metric, collect(w) .+ 2) // (N^2 - 1)
+    @assert denominator(id) == 1
+    return numerator(id)
+end
+
+function irreps_by_dim(::Type{SUNIrrep{N}}, d::Int, maxdynkin::Int=3) where {N}
+    irreps = SUNIrrep{N}[]
+    
+    all_dynkin = CartesianIndices(ntuple(k -> maxdynkin + 1, N-1))
+    for a in all_dynkin
+        I = from_dynkin_label(a.I .- 1)
+        dim(I) == d && push!(irreps, I)
+    end
+    
+    return sort!(irreps; by=x -> (index(x), congruency(x), dynkin_label(x)...))
+end
+
+"""
+    dimname(I::SUNIrrep) -> String
+
+Returns the dimensional name of an irrep, e.g. "6" for the 6-dimensional irrep of SU(3).
+When there are multiple irreps with the same dimension, they are sorted by index and the
+number of primes `′` indicates the position in that list.
+Dual representations have the same
+dimension and index, and by convention the one with the lowest congruency class is chosen as
+the "non-dual" one, and the other one is marked with a `†`.
+If the congruency class are the
+same, the one with the lowest Dynkin label, compared lexicographically, is chosen as the
+"non-dual" one.
+
+!!! warning
+
+    This function necessarily has to scan through all irreps to list those that have the
+    same dimension, and therefore an appropriate cutoff has to be chosen. By default, the
+    search space is all irreps with Dynkin labels up to 1 higher than the maximal label of
+    `s` for SU{N} with `N <= 4`, and up to the maximal Dynkin label for `N > 4`. This means
+    that it is possible that the number of primes is not consistent. Nevertheless, these
+    labels are never used internally and should thus not cause any problems.
+"""
+function dimname(s::SUNIrrep{N}) where {N}
+    # for some reason in SU{3}, the 6-dimensional irreps have switched duality
+    s == SUNIrrep(2, 0, 0) && return "6"
+    s == SUNIrrep(2, 2, 0) && return "6†"
+    
+    a = dynkin_label(s)
+    max_dynkin_label = N > 4 ? maximum(a) : maximum(a) + 1
+    d = dim(s)
+    
+    same_dim_irreps = irreps_by_dim(typeof(s), d, max_dynkin_label)
+    
+    if length(same_dim_irreps) > 1
+        ids = index.(same_dim_irreps)
+        numprimes = findfirst(==(index(s)), unique!(ids)) - 1
+        if congruency(s) == 0
+            conjugate = s != first(filter(x -> index(x)==(index(s)), same_dim_irreps))
+        else
+            conjugate = congruency(s) > congruency(dual(s))
+        end
+    else
+        numprimes = 0
+        conjugate = false
+    end
+
+    name = conjugate ? string(d) * str_dual : string(d)
+    return name * repeat(str_prime, numprimes)
+end
+
+const str_dual = "†"
+const str_prime = "′"
+
+function SUNIrrep{N}(name::AbstractString) where {N}
+    d = parse(Int, filter(isdigit, name))
+    numprimes = count(x -> x == str_prime, name)
+    conjugate = contains(name, str_dual)
+
+    max_dynkin = max_dynkin_label(SUNIrrep{N})
+
+    same_dim_irreps = irreps_by_dim(SUNIrrep{N}, d, max_dynkin)
+    isempty(same_dim_irreps) &&
+        throw(ArgumentError("Either the name $name is not valid for SU{$N} or the irrep has at least one Dynkin label higher than $max_dynkin. You can expand the search space with `SUNRepresentations.max_dynkin_label(SUNIrrep{$N}) = a`."))
+
+    id = unique!(index.(same_dim_irreps))[numprimes + 1]
+    same_id_irreps = filter(x -> index(x) == id, same_dim_irreps)
+
+    return conjugate ? last(same_id_irreps) : first(same_id_irreps)
+end

--- a/src/sector.jl
+++ b/src/sector.jl
@@ -1,8 +1,16 @@
 export SUNIrrep
 
 # is this type piracy?
-Base.getindex(::TensorKit.IrrepTable, ::Type{TensorKit.SU{N}}) where {N} = SUNIrrep{N}
+const SU₃ = SU{3}
+const SU₄ = SU{4}
+const SU₅ = SU{5}
+TensorKit.type_repr(::Type{SU₃}) = "SU₃"
+TensorKit.type_repr(::Type{SU₄}) = "SU₄"
+TensorKit.type_repr(::Type{SU₅}) = "SU₅"
+Base.getindex(::TensorKit.IrrepTable, ::Type{SU{N}}) where {N} = SUNIrrep{N}
+
 Base.convert(::Type{SUNIrrep{N}}, I::NTuple{N,Int}) where {N} = SUNIrrep{N}(I)
+Base.convert(::Type{SUNIrrep{N}}, I::Vector{Int}) where {N} = SUNIrrep{N}(I)
 Base.IteratorSize(::Type{TensorKit.SectorValues{T}}) where {T<:SUNIrrep} = Base.IsInfinite()
 
 function Base.iterate(::TensorKit.SectorValues{SUNIrrep{N}}, I=ntuple(zero, N)) where {N}

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -29,27 +29,18 @@ using Latexify: latexify, @L_str
     for k in 1:N
         @test parse(Int, s[17 + 2 * k]) == weight(I1)[k]
     end
-    
+
     @test inv(cartanmatrix(I1)) ≈ inverse_cartanmatrix(I1)
     @test SUNIrrep{N}("1") === one(SUNIrrep{N})
 end
 
-
 @timedtestset "Names of SU3Irrep:" begin
     dimnames = ["1", "3", "3⁺", "6", "8", "6⁺", "10⁺", "15", "15⁺", "10", "15′", "24⁺",
                 "27", "24", "15′⁺", "21⁺", "35⁺", "42", "42⁺", "35"]
-    latexnames = [L"$\textbf{1}$", L"$\textbf{3}$", L"$\overline{\textbf{3}}$",
-                  L"$\textbf{6}$", L"$\textbf{8}$", L"$\overline{\textbf{6}}$",
-                  L"$\overline{\textbf{10}}$", L"$\textbf{15}$",
-                  L"$\overline{\textbf{15}}$", L"$\textbf{10}$", L"$\textbf{15}^\prime$",
-                  L"$\overline{\textbf{24}}$", L"$\textbf{27}$", L"$\textbf{24}$",
-                  L"$\overline{\textbf{15}}^\prime$", L"$\overline{\textbf{21}}$",
-                  L"$\overline{\textbf{35}}$", L"$\textbf{42}$",
-                  L"$\overline{\textbf{42}}$", L"$\textbf{35}$"]
+
     for (i, I) in enumerate(values(SU3Irrep))
         i > length(dimnames) && break
         @test dimname(I) == dimnames[i]
-        @test latexify(I) == latexnames[i]
         @test SU3Irrep(dimnames[i]) === I
         @test SU3Irrep(collect(dynkin_label(I))) === I
     end
@@ -58,19 +49,10 @@ end
 @timedtestset "Names of SU4Irrep:" begin
     dimnames = ["1", "4", "6", "4⁺", "10⁺", "20⁺", "15", "20′", "20", "10", "20″⁺", "45⁺",
                 "36", "60", "64", "36⁺", "50", "60⁺", "45", "20″"]
-    latexnames = [L"$\textbf{1}$", L"$\textbf{4}$", L"$\textbf{6}$",
-                  L"$\overline{\textbf{4}}$", L"$\overline{\textbf{10}}$",
-                  L"$\overline{\textbf{20}}$", L"$\textbf{15}$", L"$\textbf{20}^\prime$",
-                  L"$\textbf{20}$", L"$\textbf{10}$",
-                  L"$\overline{\textbf{20}}^{\prime\prime}$", L"$\overline{\textbf{45}}$",
-                  L"$\textbf{36}$", L"$\textbf{60}$", L"$\textbf{64}$",
-                  L"$\overline{\textbf{36}}$", L"$\textbf{50}$",
-                  L"$\overline{\textbf{60}}$", L"$\textbf{45}$",
-                  L"$\textbf{20}^{\prime\prime}$"]
+
     for (i, I) in enumerate(values(SU4Irrep))
         i > length(dimnames) && break
         @test dimname(I) == dimnames[i]
-        @test latexify(I) == latexnames[i]
         @test SU4Irrep(dimnames[i]) === I
         @test SU4Irrep(collect(dynkin_label(I))) === I
     end
@@ -79,19 +61,63 @@ end
 @timedtestset "Names of SU5Irrep:" begin
     dimnames = ["1", "5", "10", "10⁺", "5⁺", "15", "40⁺", "45⁺", "24", "50⁺", "75", "45",
                 "50", "40", "15⁺", "35⁺", "105⁺", "126⁺", "70", "175′⁺"]
-    latexnames = [L"$\textbf{1}$", L"$\textbf{5}$", L"$\textbf{10}$",
-                  L"$\overline{\textbf{10}}$", L"$\overline{\textbf{5}}$", L"$\textbf{15}$",
-                  L"$\overline{\textbf{40}}$", L"$\overline{\textbf{45}}$",
-                  L"$\textbf{24}$", L"$\overline{\textbf{50}}$", L"$\textbf{75}$",
-                  L"$\textbf{45}$", L"$\textbf{50}$", L"$\textbf{40}$",
-                  L"$\overline{\textbf{15}}$", L"$\overline{\textbf{35}}$",
-                  L"$\overline{\textbf{105}}$", L"$\overline{\textbf{126}}$",
-                  L"$\textbf{70}$", L"$\overline{\textbf{175}}^\prime$"]
+
     for (i, I) in enumerate(values(SU5Irrep))
         i > length(dimnames) && break
         @test dimname(I) == dimnames[i]
-        @test latexify(I) == latexnames[i]
         @test SU5Irrep(dimnames[i]) === I
         @test SU5Irrep(collect(dynkin_label(I))) === I
+    end
+end
+
+if VERSION >= v"1.9"
+    @timedtestset "LaTeX names of SU3Irrep" begin
+        latexnames = [L"$\textbf{1}$", L"$\textbf{3}$", L"$\overline{\textbf{3}}$",
+                      L"$\textbf{6}$", L"$\textbf{8}$", L"$\overline{\textbf{6}}$",
+                      L"$\overline{\textbf{10}}$", L"$\textbf{15}$",
+                      L"$\overline{\textbf{15}}$", L"$\textbf{10}$",
+                      L"$\textbf{15}^\prime$",
+                      L"$\overline{\textbf{24}}$", L"$\textbf{27}$", L"$\textbf{24}$",
+                      L"$\overline{\textbf{15}}^\prime$", L"$\overline{\textbf{21}}$",
+                      L"$\overline{\textbf{35}}$", L"$\textbf{42}$",
+                      L"$\overline{\textbf{42}}$", L"$\textbf{35}$"]
+        for (i, I) in enumerate(values(SU3Irrep))
+            i > length(latexnames) && break
+            @test latexify(I) == latexnames[i]
+        end
+    end
+
+    @timedtestset "LaTeX names of SU4Irrep" begin
+        latexnames = [L"$\textbf{1}$", L"$\textbf{4}$", L"$\textbf{6}$",
+                      L"$\overline{\textbf{4}}$", L"$\overline{\textbf{10}}$",
+                      L"$\overline{\textbf{20}}$", L"$\textbf{15}$",
+                      L"$\textbf{20}^\prime$",
+                      L"$\textbf{20}$", L"$\textbf{10}$",
+                      L"$\overline{\textbf{20}}^{\prime\prime}$",
+                      L"$\overline{\textbf{45}}$",
+                      L"$\textbf{36}$", L"$\textbf{60}$", L"$\textbf{64}$",
+                      L"$\overline{\textbf{36}}$", L"$\textbf{50}$",
+                      L"$\overline{\textbf{60}}$", L"$\textbf{45}$",
+                      L"$\textbf{20}^{\prime\prime}$"]
+        for (i, I) in enumerate(values(SU4Irrep))
+            i > length(latexnames) && break
+            @test latexify(I) == latexnames[i]
+        end
+    end
+
+    @timedtestset "LaTeX names of SU5Irrep" begin
+        latexnames = [L"$\textbf{1}$", L"$\textbf{5}$", L"$\textbf{10}$",
+                      L"$\overline{\textbf{10}}$", L"$\overline{\textbf{5}}$",
+                      L"$\textbf{15}$",
+                      L"$\overline{\textbf{40}}$", L"$\overline{\textbf{45}}$",
+                      L"$\textbf{24}$", L"$\overline{\textbf{50}}$", L"$\textbf{75}$",
+                      L"$\textbf{45}$", L"$\textbf{50}$", L"$\textbf{40}$",
+                      L"$\overline{\textbf{15}}$", L"$\overline{\textbf{35}}$",
+                      L"$\overline{\textbf{105}}$", L"$\overline{\textbf{126}}$",
+                      L"$\textbf{70}$", L"$\overline{\textbf{175}}^\prime$"]
+        for (i, I) in enumerate(values(SU5Irrep))
+            i > length(latexnames) && break
+            @test latexify(I) == latexnames[i]
+        end
     end
 end

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -1,6 +1,10 @@
 println("------------------------------------")
 println("Generic SUNIrrep tests")
 println("------------------------------------")
+
+using SUNRepresentations: cartanmatrix, inverse_cartanmatrix, dimname, dynkin_label
+using Latexify: latexify, @L_str
+
 @timedtestset "Basic tests for SUNIrrep{$N}:" for N in 2:5
     I1 = SUNIrrep(tuple(sort(rand(1:9, N); rev=true)..., 1))
     I2 = SUNIrrep(tuple(sort(rand(1:9, N); rev=true)..., 1))
@@ -27,31 +31,67 @@ println("------------------------------------")
     end
     
     @test inv(cartanmatrix(I1)) ≈ inverse_cartanmatrix(I1)
+    @test SUNIrrep{N}("1") === one(SUNIrrep{N})
 end
 
-@timedtestset "Properties of SUNIrrep{2}:" begin
-    indices = [1, 4, 10, 20, 35, 56, 84, 120, 165, 220]
-    for i in 1:10
-        I = SUNIrrep(i, 0)
-        @test dynkin_label(I) == (i,)
-        @test congruency(I) == i % 2
-        @test index(I) == indices[i]
-        @test dimname(I) == "$(dim(I))"
+
+@timedtestset "Names of SU3Irrep:" begin
+    dimnames = ["1", "3", "3⁺", "6", "8", "6⁺", "10⁺", "15", "15⁺", "10", "15′", "24⁺",
+                "27", "24", "15′⁺", "21⁺", "35⁺", "42", "42⁺", "35"]
+    latexnames = [L"$\textbf{1}$", L"$\textbf{3}$", L"$\overline{\textbf{3}}$",
+                  L"$\textbf{6}$", L"$\textbf{8}$", L"$\overline{\textbf{6}}$",
+                  L"$\overline{\textbf{10}}$", L"$\textbf{15}$",
+                  L"$\overline{\textbf{15}}$", L"$\textbf{10}$", L"$\textbf{15}^\prime$",
+                  L"$\overline{\textbf{24}}$", L"$\textbf{27}$", L"$\textbf{24}$",
+                  L"$\overline{\textbf{15}}^\prime$", L"$\overline{\textbf{21}}$",
+                  L"$\overline{\textbf{35}}$", L"$\textbf{42}$",
+                  L"$\overline{\textbf{42}}$", L"$\textbf{35}$"]
+    for (i, I) in enumerate(values(SU3Irrep))
+        i > length(dimnames) && break
+        @test dimname(I) == dimnames[i]
+        @test latexify(I) == latexnames[i]
+        @test SU3Irrep(dimnames[i]) === I
+        @test SU3Irrep(collect(dynkin_label(I))) === I
     end
 end
 
-@timedtestset "Properties of SUNIrrep{3}:" begin
-    
-    
-    
-    irreps = (SUNIrrep(1, 0, 0), SUNIrrep(2, 0, 0), SUNIrrep(2, 1, 0), SUNIrrep(3, 0, 0),
-              SUNIrrep(3, 1, 0), SUNIrrep(4, 0, 0))
-    dims = (3, 6, 8, 10, 15, 15)
-    indices = (1, 5, 6, 15, 20, 35)
-    names = ("3", "6", "8", "10", "15", "15′")
-    for (i, I) in enumerate(irreps)
-        @test dynkin_label(I) == (I.I[1] - I.I[2], I.I[2] - I.I[3])
-        @test congruency(I) == (I.I[1] + I.I[2] + I.I[3]) % 3
-        @test index(I) == indices[i]
+@timedtestset "Names of SU4Irrep:" begin
+    dimnames = ["1", "4", "6", "4⁺", "10⁺", "20⁺", "15", "20′", "20", "10", "20″⁺", "45⁺",
+                "36", "60", "64", "36⁺", "50", "60⁺", "45", "20″"]
+    latexnames = [L"$\textbf{1}$", L"$\textbf{4}$", L"$\textbf{6}$",
+                  L"$\overline{\textbf{4}}$", L"$\overline{\textbf{10}}$",
+                  L"$\overline{\textbf{20}}$", L"$\textbf{15}$", L"$\textbf{20}^\prime$",
+                  L"$\textbf{20}$", L"$\textbf{10}$",
+                  L"$\overline{\textbf{20}}^{\prime\prime}$", L"$\overline{\textbf{45}}$",
+                  L"$\textbf{36}$", L"$\textbf{60}$", L"$\textbf{64}$",
+                  L"$\overline{\textbf{36}}$", L"$\textbf{50}$",
+                  L"$\overline{\textbf{60}}$", L"$\textbf{45}$",
+                  L"$\textbf{20}^{\prime\prime}$"]
+    for (i, I) in enumerate(values(SU4Irrep))
+        i > length(dimnames) && break
+        @test dimname(I) == dimnames[i]
+        @test latexify(I) == latexnames[i]
+        @test SU4Irrep(dimnames[i]) === I
+        @test SU4Irrep(collect(dynkin_label(I))) === I
+    end
+end
+
+@timedtestset "Names of SU5Irrep:" begin
+    dimnames = ["1", "5", "10", "10⁺", "5⁺", "15", "40⁺", "45⁺", "24", "50⁺", "75", "45",
+                "50", "40", "15⁺", "35⁺", "105⁺", "126⁺", "70", "175′⁺"]
+    latexnames = [L"$\textbf{1}$", L"$\textbf{5}$", L"$\textbf{10}$",
+                  L"$\overline{\textbf{10}}$", L"$\overline{\textbf{5}}$", L"$\textbf{15}$",
+                  L"$\overline{\textbf{40}}$", L"$\overline{\textbf{45}}$",
+                  L"$\textbf{24}$", L"$\overline{\textbf{50}}$", L"$\textbf{75}$",
+                  L"$\textbf{45}$", L"$\textbf{50}$", L"$\textbf{40}$",
+                  L"$\overline{\textbf{15}}$", L"$\overline{\textbf{35}}$",
+                  L"$\overline{\textbf{105}}$", L"$\overline{\textbf{126}}$",
+                  L"$\textbf{70}$", L"$\overline{\textbf{175}}^\prime$"]
+    for (i, I) in enumerate(values(SU5Irrep))
+        i > length(dimnames) && break
+        @test dimname(I) == dimnames[i]
+        @test latexify(I) == latexnames[i]
+        @test SU5Irrep(dimnames[i]) === I
+        @test SU5Irrep(collect(dynkin_label(I))) === I
     end
 end

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -25,4 +25,33 @@ println("------------------------------------")
     for k in 1:N
         @test parse(Int, s[17 + 2 * k]) == weight(I1)[k]
     end
+    
+    @test inv(cartanmatrix(I1)) ≈ inverse_cartanmatrix(I1)
+end
+
+@timedtestset "Properties of SUNIrrep{2}:" begin
+    indices = [1, 4, 10, 20, 35, 56, 84, 120, 165, 220]
+    for i in 1:10
+        I = SUNIrrep(i, 0)
+        @test dynkin_label(I) == (i,)
+        @test congruency(I) == i % 2
+        @test index(I) == indices[i]
+        @test dimname(I) == "$(dim(I))"
+    end
+end
+
+@timedtestset "Properties of SUNIrrep{3}:" begin
+    
+    
+    
+    irreps = (SUNIrrep(1, 0, 0), SUNIrrep(2, 0, 0), SUNIrrep(2, 1, 0), SUNIrrep(3, 0, 0),
+              SUNIrrep(3, 1, 0), SUNIrrep(4, 0, 0))
+    dims = (3, 6, 8, 10, 15, 15)
+    indices = (1, 5, 6, 15, 20, 35)
+    names = ("3", "6", "8", "10", "15", "15′")
+    for (i, I) in enumerate(irreps)
+        @test dynkin_label(I) == (I.I[1] - I.I[2], I.I[2] - I.I[3])
+        @test congruency(I) == (I.I[1] + I.I[2] + I.I[3]) % 3
+        @test index(I) == indices[i]
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using TestExtras
 using Random
 using TensorKit
-using SUNRepresentations: SUNIrrep
+using SUNRepresentations
 using Combinatorics
 using TensorKit
 using TensorKit: ProductSector, fusiontensor, pentagon_equation, hexagon_equation

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -5,7 +5,14 @@ for I in sectorlist
     ti = time()
     @testset "Sector $I: Basic properties" begin
         s = (randsector(I), randsector(I), randsector(I))
-        @test eval(Meta.parse(sprint(show, s[1]))) == s[1]
+
+        mode_old = SUNRepresentations.display_mode("dimension")
+        for mode in ["dimension", "dynkin", "weight"]
+            SUNRepresentations.display_mode(mode)
+            @test eval(Meta.parse(sprint(show, s[1]))) == s[1]
+        end
+        SUNRepresentations.display_mode(mode_old)
+
         @test @constinferred(hash(s[1])) == hash(deepcopy(s[1]))
         @test @constinferred(one(s[1])) == @constinferred(one(I))
         @constinferred dual(s[1])


### PR DESCRIPTION
This PR adds the posibility to specify irreps through various conventions:
- Weight names (status quo + storage): `SUNIrrep(I1, I2, ..., I_{N-1}, 0)` or `SUNIrrep{N}(I1, I2, ..., I_{N-1}, 0)`
- Dynkin labels: `SUNIrrep([a1, a2, ..., a_{n-1}])` or `SUNIrrep{N}([a1, a2, ..., a_{n-1}])`
- Dimensional names: `SUNIrrep{N}(name::AbstractString)`

Additionally, the user can select their preferred output format for `print` and `show` through a preference-based system:
```julia-repl
julia> using SUNRepresentations
julia> for mode in ["weight", "dynkin", "dimension"]
           SUNRepresentations.display_mode(mode)
           @show SUNIrrep(2,2,2,0)
       end
SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]((2, 2, 2, 0))
SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]([0, 0, 2])
SUNIrrep(2, 2, 2, 0) = Irrep[SU₄]("10")
```

As an added benefit, this also exports `dynkin_label` and `congruence`, which allow access to some convenient properties of irreps.

For convenience, a package extension is also added for `Latexify.jl`, to obtain the latex-compatible form:
```julia-repl
julia> using Latexify
julia> latexify(SUNIrrep{4}("10⁺"))
L"$\overline{\textbf{10}}$"
```

Finally, the package now reexports `SU{N}` from TensorKit, as well as defines and exports the unicode aliases `SU₃`, `SU₄` and `SU₅`. There are also the short-hands `SU3Irrep`, `SU4Irrep` and `SU5Irrep`.