### PR TITLE
Cache Fsymbol and Rsymbols on disk

### DIFF
--- a/src/caching.jl
+++ b/src/caching.jl
@@ -1,14 +1,27 @@
+#= 
+Wait at most 1 min before deciding to overwrite.
+This should avoid deadlocking if a process started writing but got killed before removing the pidfile.
+=#
+"""
+    const _PID_STALE_AGE = 60.0
+
+Timeout for stale PID files in seconds.
+"""
+const _PID_STALE_AGE = 60.0
+
+# convert sector to string key
+_key(s::SUNIrrep) = string(weight(s))
+
+# Clebsch-Gordan coefficients
+# ---------------------------
 """
     CGC_CACHE = LRU{Any,SparseArray{Float64,4}}(; maxsize=100_000)
 
 Global cache for storing Clebsch-Gordan Coefficients.
 """
 const CGC_CACHE = LRU{Any,SparseArray{Float64,4}}(; maxsize=100_000)
-
-# convert sector to string key
-_key(s::SUNIrrep) = string(weight(s))
-
 const CGC_CACHE_PATH = @get_scratch!("CGC")
+
 function cgc_cachepath(s1::SUNIrrep{N}, s2::SUNIrrep{N}, T=Float64) where {N}
     return joinpath(CGC_CACHE_PATH, string(N), string(T), _key(s1), _key(s2))
 end
@@ -30,17 +43,6 @@ function tryread(::Type{T}, s1::SUNIrrep{N}, s2::SUNIrrep{N}, s3::SUNIrrep{N}) w
 
     return nothing
 end
-
-#= 
-Wait at most 1 min before deciding to overwrite.
-This should avoid deadlocking if a process started writing but got killed before removing the pidfile.
-=#
-"""
-    const _PID_STALE_AGE = 60.0
-
-Timeout for stale PID files in seconds.
-"""
-const _PID_STALE_AGE = 60.0
 
 function generate_all_CGCs(::Type{T}, s1::SUNIrrep{N}, s2::SUNIrrep{N}) where {T,N}
     @debug "Generating CGCs: $s1 ⊗ $s2"
@@ -88,6 +90,99 @@ function precompute_disk_cache(N, a_max::Int=1, T::Type{<:Number}=Float64; force
     return nothing
 end
 
+# F symbols
+# ---------
+
+"""
+    F_CACHE = LRU{Any,Array{Float64,4}}(; maxsize=100_000)
+
+Global cache for storing F-symbols.
+"""
+const F_CACHE = LRU{Any,Array{Float64,4}}(; maxsize=100_000)
+const F_CACHE_PATH = @get_scratch!("Fsymbol")
+_fkey(e, f) = "$(_key(e))_$(_key(f))"
+
+# TODO: verify that this file doesn't become too large
+function f_cachepath(a::I, b::I, c::I, d::I) where {N,I<:SUNIrrep{N}}
+    return joinpath(F_CACHE_PATH, string(N), join(_key.((a, b, c, d)), '_'))
+end
+
+function tryread_F(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
+                   d::SUNIrrep{N}, e::SUNIrrep{N}, f::SUNIrrep{N}) where {N}
+    fn = f_cachepath(a, b, c, d)
+    isfile(fn * ".jld2") || return nothing
+
+    F = mkpidlock(fn * ".pid"; stale_age=_PID_STALE_AGE) do
+        try
+            return jldopen(fn * ".jld2", "r"; parallel_read=true) do file
+                !haskey(file, _fkey(e, f)) && return nothing
+                return file[_fkey(e, f)]::Array{Float64,4}
+            end
+        catch
+            return nothing
+        end
+    end
+    isnothing(F) || @debug "loaded Fsymbol from disk: $a $b $c $d"
+    return F
+end
+
+function generate_F(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
+                    d::SUNIrrep{N}, e::SUNIrrep{N}, f::SUNIrrep{N}) where {N}
+    @debug "Generating Fsymbol: $a $b $c $d $e $f"
+    F = _Fsymbol(a, b, c, d, e, f)
+    fn = f_cachepath(a, b, c, d)
+    isdir(dirname(fn)) || mkpath(dirname(fn))
+
+    key = _fkey(e, f)
+    mkpidlock(fn * ".pid"; stale_age=_PID_STALE_AGE) do
+        return jldopen(fn * ".jld2", "a+") do file
+            if !haskey(file, key)
+                file[key] = F
+            end
+        end
+    end
+
+    return F
+end
+
+function generate_all_Fs(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
+                         d::SUNIrrep{N}) where {N}
+    @debug "Generating all Fs: $a $b $c $d"
+    es = collect(intersect(⊗(a, b), map(dual, ⊗(c, dual(d)))))
+    fs = collect(intersect(⊗(b, c), map(dual, ⊗(dual(d), a))))
+    Fs = Dict(_fkey(e, f) => Fsymbol(a, b, c, d, e, f) for e in es, f in fs)
+    return Fs
+end
+
+"""
+    precompute_disk_cache_F(N, a_max, [T=Float64]; force=false)
+
+Populate the disk cache for ``SU(N)`` with eltype `T` with all Fsymbols with Dynkin labels up to
+``a_max``.
+Will not recompute Fsymbols that are already in the cache, unless `force=true`.
+"""
+function precompute_disk_cache_F(N, a_max::Int=1; force=false)
+    all_irreps = all_dynkin(SUNIrrep{N}, a_max)
+    for a in all_irreps, b in all_irreps, c in all_irreps
+        for d in ⊗(a, b, c)
+            maximum(dynkin_label(d)) ≤ a_max || continue
+            if force || !isfile(f_cachepath(a, b, c, d) * ".jld2")
+                generate_all_Fs(a, b, c, d)
+            end
+        end
+    end
+    disk_cache_F_info()
+    return nothing
+end
+
+"""
+    R_CACHE = LRU{Any,Matrix{Float64}}(; maxsize=100_000)
+
+Global cache for storing R-symbols.
+"""
+const R_CACHE = LRU{Any,Matrix{Float64}}(; maxsize=100_000)
+const R_CACHE_PATH = @get_scratch!("Rsymbol")
+
 """
     clear_disk_cache!([N, [T]])
 
@@ -116,12 +211,14 @@ function clear_disk_cache!()
 end
 
 function ram_cache_info(io::IO=stdout)
-    if isempty(CGC_CACHE)
-        println(io, "CGC RAM cache is empty.")
-    else
-        info = LRUCache.cache_info(CGC_CACHE)
-        println(io, "CGC RAM cache info:")
-        println(io, info)
+    for (name, cache) in zip(("CGC", "F", "R"), (CGC_CACHE, F_CACHE, R_CACHE))
+        if isempty(cache)
+            println(io, "$name RAM cache is empty.")
+        else
+            info = LRUCache.cache_info(cache)
+            println(io, "$name RAM cache info:")
+            println(io, info)
+        end
     end
     return nothing
 end
@@ -132,6 +229,13 @@ end
 Print information about the CGC disk cache to `io`. If `clean=true`, remove any corrupted files.
 """
 function disk_cache_info(io::IO=stdout; clean=false)
+    disk_cache_CGC_info(io; clean)
+    disk_cache_F_info(io; clean)
+    disk_cache_R_info(io; clean)
+    return nothing
+end
+
+function disk_cache_CGC_info(io::IO=stdout; clean=false)
     if !isdir(CGC_CACHE_PATH) || isempty(readdir(CGC_CACHE_PATH))
         println("CGC disk cache is empty.")
         return nothing
@@ -145,28 +249,73 @@ function disk_cache_info(io::IO=stdout; clean=false)
         for fldr_T in readdir(fldr_N; join=true)
             isdir(fldr_T) || continue
             T = basename(fldr_T)
-            n_bytes = 0
-            n_entries = 0
-            for (root, _, files) in walkdir(fldr_T)
-                for f in files
-                    # wrap in try/catch to avoid stopping the loop if a file is corrupted
-                    try
-                        n_entries += jldopen(file -> length(keys(file)), joinpath(root, f),
-                                             "r")
-                        n_bytes += filesize(joinpath(root, f))
-                    catch e
-                        println(io, "Error in file $(joinpath(root, f)) : $e")
-                        if clean
-                            rm(joinpath(root, f); force=true)
-                        end
-                    end
-                end
-            end
+            n_entries, n_bytes = summarize_folder(fldr_T; clean)
             println(io,
                     "* SU($N) - $T - $(n_entries) entries - $(Base.format_bytes(n_bytes))")
         end
     end
+    println(io)
     return nothing
+end
+
+function disk_cache_F_info(io::IO=stdout; clean=false)
+    if !isdir(F_CACHE_PATH) || isempty(readdir(F_CACHE_PATH))
+        println("F disk cache is empty.")
+        return nothing
+    end
+    println(io, "F disk cache info:")
+    println(io, "==================")
+
+    for fldr_N in readdir(F_CACHE_PATH; join=true)
+        isdir(fldr_N) || continue
+        N = basename(fldr_N)
+        n_entries, n_bytes, n_files = summarize_folder(fldr_N; clean)
+        println(io,
+                "* SU($N) - $(n_files) files - $(n_entries) entries - $(Base.format_bytes(n_bytes))")
+    end
+    println(io)
+    return nothing
+end
+
+function disk_cache_R_info(io::IO=stdout; clean=false)
+    if !isdir(R_CACHE_PATH) || isempty(readdir(R_CACHE_PATH))
+        println("R disk cache is empty.")
+        return nothing
+    end
+    println(io, "R disk cache info:")
+    println(io, "==================")
+
+    for fldr_N in readdir(R_CACHE_PATH; join=true)
+        isdir(fldr_N) || continue
+        N = basename(fldr_N)
+        n_entries, n_bytes, n_files = summarize_folder(fldr_N; clean)
+        println(io,
+                "* SU($N) - $(n_files) files - $(n_entries) entries - $(Base.format_bytes(n_bytes))")
+    end
+    println(io)
+    return nothing
+end
+
+function summarize_folder(folder; clean=false)
+    n_bytes = 0
+    n_entries = 0
+    n_files = 0
+    for (root, _, files) in walkdir(folder)
+        for f in files
+            # wrap in try/catch to avoid stopping the loop if a file is corrupted
+            try
+                n_entries += jldopen(file -> length(keys(file)), joinpath(root, f), "r")
+                n_bytes += filesize(joinpath(root, f))
+                n_files += 1
+            catch e
+                println(io, "Error in file $(joinpath(root, f)) : $e")
+                if clean
+                    rm(joinpath(root, f); force=true)
+                end
+            end
+        end
+    end
+    return n_entries, n_bytes, n_files
 end
 
 """

--- a/src/sector.jl
+++ b/src/sector.jl
@@ -50,7 +50,6 @@ function TensorKitSectors.fusiontensor(s1::SUNIrrep{N}, s2::SUNIrrep{N},
     return CGC(Float64, s1, s2, s3)
 end
 
-const FCACHE = LRU{Int,Any}(; maxsize=10)
 function TensorKitSectors.Fsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
                                   d::SUNIrrep{N}, e::SUNIrrep{N}, f::SUNIrrep{N}) where {N}
     return _get_F((a, b, c, d, e, f))
@@ -84,18 +83,19 @@ function _Fsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
     return Array(F)
 end
 
-const RCACHE = LRU{Int,Any}(; maxsize=10)
 function TensorKitSectors.Rsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N}) where {N}
-    key = (a, b, c)
-    K = typeof(key)
-    V = Array{Float64,2}
-    cache::LRU{K,V} = get!(RCACHE, N) do
-        return LRU{K,V}(; maxsize=10^5)
-    end
-    return get!(cache, key) do
-        return _Rsymbol(a, b, c)
-    end
+    return _get_R((a, b, c))
 end
+
+@noinline function _get_R(@nospecialize(key))
+    d::Matrix{Float64} = get!(R_CACHE, key) do
+        result = tryread_R(key...)
+        isnothing(result) || return result
+        return generate_R(key...)
+    end
+    return d
+end
+
 function _Rsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N}) where {N}
     N1 = Nsymbol(a, b, c)
     N2 = Nsymbol(b, a, c)

--- a/src/sector.jl
+++ b/src/sector.jl
@@ -53,15 +53,16 @@ end
 const FCACHE = LRU{Int,Any}(; maxsize=10)
 function TensorKitSectors.Fsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
                                   d::SUNIrrep{N}, e::SUNIrrep{N}, f::SUNIrrep{N}) where {N}
-    key = (a, b, c, d, e, f)
-    K = typeof(key)
-    V = Array{Float64,4}
-    cache::LRU{K,V} = get!(FCACHE, N) do
-        return LRU{K,V}(; maxsize=10^5)
+    return _get_F((a, b, c, d, e, f))
+end
+
+@noinline function _get_F(@nospecialize(key))
+    d::Array{Float64,4} = get!(F_CACHE, key) do
+        result = tryread_F(key...)
+        isnothing(result) || return result
+        return generate_F(key...)
     end
-    return get!(cache, key) do
-        return _Fsymbol(a, b, c, d, e, f)
-    end
+    return d
 end
 function _Fsymbol(a::SUNIrrep{N}, b::SUNIrrep{N}, c::SUNIrrep{N},
                   d::SUNIrrep{N}, e::SUNIrrep{N}, f::SUNIrrep{N}) where {N}


### PR DESCRIPTION
This PR updates the Fsymbols and Rsymbols to be stored on disk as well.
The main motivation is that typically, the CGCs take up way more space than the actual F and Rsymbols, so it may be reasonable to have a single machine that precomputes a lot of them and then not bother with copying the (possible terrabytes of) CGCs.

For reference, I currently have:

```
CGC disk cache info:
====================
* SU(3) - Float64 - 3439 entries - 203.759 MiB
* SU(4) - Float64 - 10833 entries - 51.241 GiB
* SU(5) - Float64 - 1680 entries - 1.004 GiB

F disk cache info:
==================
* SU(3) - 22079 files - 424083 entries - 101.769 MiB
* SU(4) - 16468 files - 130003 entries - 37.697 MiB
* SU(5) - 5848 files - 18989 entries - 7.093 MiB

R disk cache info:
==================
* SU(3) - 116 files - 512 entries - 146.276 KiB
* SU(4) - 141 files - 488 entries - 159.426 KiB
* SU(5) - 149 files - 542 entries - 173.374 KiB
```